### PR TITLE
PATCH: Rake Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ telco.send(number: '+244923456789', message: 'Hello World\nNext line', service: 
 ## Help and Docs
 
 - [TelcoSMS](http://telcosms.co.ao)
-- [RDOC](http://www.rubydoc.info/gems/telcosms/1.0.0)
+- [RDOC](http://www.rubydoc.info/gems/telcosms/1.0.1)
 
 ## Development
 

--- a/lib/telcosms/version.rb
+++ b/lib/telcosms/version.rb
@@ -1,3 +1,3 @@
 module TelcosmsModule
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/telcosms.gemspec
+++ b/telcosms.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_dependency 'httparty', "~> 0.18.1"
 end


### PR DESCRIPTION
# Patch
- moderate severity
- Vulnerable versions: <= 12.3.2
- Patched version: 12.3.3
- There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.